### PR TITLE
Update github actions artifact upload version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
       continue-on-error: true
 
     - name: Upload security reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: security-reports-${{ github.sha }}
         path: |
@@ -277,7 +277,7 @@ jobs:
         META_MCP_SECRET_KEY: test-secret-key-for-testing-only
 
     - name: Upload benchmark results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: benchmark-results-${{ github.sha }}
         path: benchmark-results.json

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,7 @@ jobs:
         mkdocs build --clean --strict
 
     - name: Upload documentation artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: documentation-${{ github.sha }}
         path: site/
@@ -94,7 +94,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Download documentation artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: documentation-${{ github.sha }}
         path: site/


### PR DESCRIPTION
Update GitHub Actions `upload-artifact` and `download-artifact` to v4 to fix deprecation errors.

---

[Open in Web](https://cursor.com/agents?id=bc-322b6a35-098a-488d-a3a2-e2eb68e85928) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-322b6a35-098a-488d-a3a2-e2eb68e85928) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)